### PR TITLE
Bugfix/java enum old way

### DIFF
--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerDefinition.scala
@@ -115,19 +115,6 @@ final class TransformerDefinition[From, To, C <: TransformerCfg, Flags <: Transf
   def withCoproductInstance[Inst](f: Inst => To): TransformerDefinition[From, To, _ <: TransformerCfg, Flags] =
     macro TransformerDefinitionWhiteboxMacros.withCoproductInstanceImpl[From, To, Inst, C]
 
-  /** Map exact value of a coproduct `from` to a coproduct `to`
-    *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation
-    * expects that coproducts to have matching names of its components, and for every component
-    * in `To` field's type there is matching component in `From` type. If some component is missing
-    * it fails compilation unless provided replacement with this operation.
-    *
-    * @see [[https://scalalandio.github.io/chimney/transformers/customizing-transformers.html#transforming-coproducts]] for more details
-    * @return [[io.scalaland.chimney.dsl.TransformerDefinition]]
-    */
-  def withCoproductValue[Inst](from: Inst, to: To): TransformerDefinition[From, To, _ <: TransformerCfg, Flags] =
-    macro TransformerDefinitionWhiteboxMacros.withCoproductValue[From, To, Inst, C]
-
   /** Use `f` to calculate the (missing) wrapped coproduct instance when mapping one coproduct into another
     *
     * By default if mapping one coproduct in `From` into another coproduct in `To` derivation

--- a/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/dsl/TransformerInto.scala
@@ -116,19 +116,6 @@ final class TransformerInto[From, To, C <: TransformerCfg, Flags <: TransformerF
   def withCoproductInstance[Inst](f: Inst => To): TransformerInto[From, To, _ <: TransformerCfg, Flags] =
     macro TransformerIntoWhiteboxMacros.withCoproductInstanceImpl
 
-  /** Map exact value of a coproduct `from` to a coproduct `to`
-    *
-    * By default if mapping one coproduct in `From` into another coproduct in `To` derivation
-    * expects that coproducts to have matching names of its components, and for every component
-    * in `To` field's type there is matching component in `From` type. If some component is missing
-    * it fails compilation unless provided replacement with this operation.
-    *
-    * @see [[https://scalalandio.github.io/chimney/transformers/customizing-transformers.html#transforming-coproducts]] for more details
-    * @return [[io.scalaland.chimney.dsl.TransformerInto]]
-    */
-  def withCoproductValue[Inst](from: Inst, to: To): TransformerInto[From, To, _ <: TransformerCfg, Flags] =
-  macro TransformerIntoWhiteboxMacros.withCoproductValue
-
   /** Use `f` to calculate the (missing) wrapped coproduct instance when mapping one coproduct into another
     *
     * By default if mapping one coproduct in `From` into another coproduct in `To` derivation

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -491,13 +491,6 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
         .groupBy(_.name.toCanonicalName)
     }
 
-  def symbolToType(s: Symbol, parent: Type): Type =
-    if (s.isJavaEnum) {
-      s.typeSignature
-    } else {
-      s.typeInSealedParent(parent)
-    }
-
   def expandSealedClasses(
       srcPrefixTree: Tree,
       config: TransformerConfig
@@ -514,7 +507,7 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
         val instanceClauses = fromInstances.flatMap { case (canonicalName, instSymbols) =>
           instSymbols.map { instSymbol =>
             val instName = instSymbol.name.toString
-            val instTpe = symbolToType(instSymbol, From)
+            val instTpe = instSymbol.typeInSealedParent(From)
 
             resolveCoproductInstance(srcPrefixTree, instTpe, To, config)
               .map { instanceTree =>
@@ -604,7 +597,7 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
         mkCoproductInstance(
           config.transformerDefinitionPrefix,
           srcPrefixTree,
-          From.typeSymbol,
+          coproductSymbol,
           To,
           config.wrapperType
         )
@@ -615,7 +608,7 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
           mkCoproductInstance(
             config.transformerDefinitionPrefix,
             srcPrefixTree,
-            From.typeSymbol,
+            coproductSymbol,
             To,
             None
           )

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerDefinitionWhiteboxMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/dsl/TransformerDefinitionWhiteboxMacros.scala
@@ -118,28 +118,6 @@ class TransformerDefinitionWhiteboxMacros(val c: whitebox.Context) extends Macro
       .refineConfig(coproductInstanceT.applyTypeArgs(instType, To, weakTypeOf[C]))
   }
 
-  def withCoproductValue[
-    From: WeakTypeTag,
-    To: WeakTypeTag,
-    Inst: WeakTypeTag,
-    C: WeakTypeTag
-  ](from: Tree, to: Tree): Tree = {
-    val To = weakTypeOf[To]
-    val Inst = weakTypeOf[Inst]
-    val (instType, instSymbol) = if (Inst.typeSymbol.isJavaEnum) {
-      from match {
-        case Literal(Constant(from: TermSymbol)) => from.typeSignature -> from
-        case _ => c.abort(c.enclosingPosition, "Provide a single constant literal!")
-      }
-    } else {
-      Inst -> Inst.typeSymbol
-    }
-    val f = q"(_: $instType) => $to"
-    c.prefix.tree
-      .addInstance(instSymbol.fullName.toString, To.typeSymbol.fullName.toString, f)
-      .refineConfig(coproductInstanceT.applyTypeArgs(instType, To, weakTypeOf[C]))
-  }
-
   def withCoproductInstanceFImpl[
       F[+_],
       From: WeakTypeTag,

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/utils/MacroUtils.scala
@@ -157,11 +157,15 @@ trait MacroUtils extends CompanionUtils {
     def typeInSealedParent(parentTpe: Type): Type = {
       s.typeSignature // Workaround for <https://issues.scala-lang.org/browse/SI-7755>
 
-      val sEta = s.asType.toType.etaExpand
-      sEta.finalResultType.substituteTypes(
-        sEta.baseType(parentTpe.typeSymbol).typeArgs.map(_.typeSymbol),
-        parentTpe.typeArgs
-      )
+      if (s.isJavaEnum) {
+        s.typeSignature
+      } else {
+        val sEta = s.asType.toType.etaExpand
+        sEta.finalResultType.substituteTypes(
+          sEta.baseType(parentTpe.typeSymbol).typeArgs.map(_.typeSymbol),
+          parentTpe.typeArgs
+        )
+      }
     }
   }
 

--- a/chimney/src/test/scala/io/scalaland/chimney/WixSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/WixSpec.scala
@@ -110,7 +110,34 @@ object WixSpec extends TestSuite {
     }
 
     "support java enum" - {
+      "allow `withCoproductInstance` with java enum values" - {
+        implicit val t: Transformer[JavaColors.Colors, richcolors.RichColor] =
+          Transformer
+            .define[JavaColors.Colors, richcolors.RichColor]
+            .withCoproductInstance{_: JavaColors.Colors.Black.type => richcolors.JetBlack}
+            .withCoproductInstance{_: JavaColors.Colors.Red.type => richcolors.SalmonRed}
+            .withCoproductInstance{_: JavaColors.Colors.Green.type => richcolors.SeawaveGreen}
+            .withCoproductInstance{_: JavaColors.Colors.Blue.type => richcolors.SkyBlue}
+            .buildTransformer
+        t.transform(JavaColors.Colors.Black) ==> richcolors.JetBlack
+      }
+
+      "allow `withCoproductInstance` with java enum type and total function" - {
+        implicit val t: Transformer[JavaColors.Colors, richcolors.RichColor] =
+          Transformer
+            .define[JavaColors.Colors, richcolors.RichColor]
+            .withCoproductInstance[JavaColors.Colors] {
+              case JavaColors.Colors.Black => richcolors.JetBlack
+              case JavaColors.Colors.Red => richcolors.SalmonRed
+              case JavaColors.Colors.Green => richcolors.SeawaveGreen
+              case JavaColors.Colors.Blue => richcolors.SkyBlue
+            }
+            .buildTransformer
+        t.transform(JavaColors.Colors.Black) ==> richcolors.JetBlack
+      }
+
       "transform java enum into java enum" - {
+
         "by canonical name" - {
           implicit def t[A]: Transformer[JavaNumbers.NumScaleUppercase, JavaNumbers.NumScale] =
             Transformer.define.buildTransformer
@@ -124,6 +151,7 @@ object WixSpec extends TestSuite {
           (JavaNumbers.NumScaleUppercase.TRILLION: JavaNumbers.NumScaleUppercase)
             .transformInto[JavaNumbers.NumScale] ==> JavaNumbers.NumScale.Trillion
         }
+
         "with customization" - {
           implicit def t[A]: Transformer[JavaNumbers.NumScaleUppercase, JavaNumbers.NumScale] =
             Transformer.define

--- a/chimney/src/test/scala/io/scalaland/chimney/WixSpec.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/WixSpec.scala
@@ -154,8 +154,8 @@ object WixSpec extends TestSuite {
 
         "with customization" - {
           implicit def t[A]: Transformer[JavaNumbers.NumScaleUppercase, JavaNumbers.NumScale] =
-            Transformer.define
-              .withCoproductValue(JavaNumbers.NumScaleUppercase.TRILLION, JavaNumbers.NumScale.Zero)
+            Transformer.define[JavaNumbers.NumScaleUppercase, JavaNumbers.NumScale]
+              .withCoproductInstance { _: JavaNumbers.NumScaleUppercase.TRILLION.type => JavaNumbers.NumScale.Zero }
               .buildTransformer
 
           (JavaNumbers.NumScaleUppercase.ZERO: JavaNumbers.NumScaleUppercase)
@@ -192,7 +192,7 @@ object WixSpec extends TestSuite {
           implicit val t: Transformer[Colors, colors2.Color] =
             Transformer
               .define[Colors, colors2.Color]
-              .withCoproductValue(Colors.Green, colors2.Red)
+              .withCoproductInstance { _: Colors.Green.type => colors2.Red }
               .buildTransformer
 
           (JavaColors.Colors.Black: Colors).transformInto[colors2.Color] ==> colors2.Black
@@ -201,9 +201,6 @@ object WixSpec extends TestSuite {
           (JavaColors.Colors.Red: Colors).transformInto[colors2.Color] ==> colors2.Red
         }
 
-        "into DSL" - {
-          (JavaColors.Colors.Green: Colors).into[colors2.Color].withCoproductValue(Colors.Green, colors2.Red).transform ==> colors2.Red
-        }
       }
 
       "transform sealed hierarchy into java enum" - {

--- a/chimney/src/test/scala/io/scalaland/chimney/examples/wix/Colors.scala
+++ b/chimney/src/test/scala/io/scalaland/chimney/examples/wix/Colors.scala
@@ -1,5 +1,13 @@
 package io.scalaland.chimney.examples.wix
 
+package richcolors {
+  sealed trait RichColor
+  case object JetBlack extends RichColor
+  case object SalmonRed extends RichColor
+  case object SeawaveGreen extends RichColor
+  case object SkyBlue extends RichColor
+}
+
 package colors4 {
   sealed trait Color
   case object RED extends Color


### PR DESCRIPTION
After playing around for a little more yesterday in the evening, I made Java enums work fully with `withCoproductInstance` method.

I removed the `withCoproductValue` to keep our interface closer to upstream (we may need to re-introduce it later when we add Enumerations support, but there's no reason to expose this method right now)