### PR TITLE
made warnings non-fatal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,6 @@ val settings = Seq(
     "-Xlint:type-parameter-shadow",
     "-Ywarn-unused:locals",
     "-Ywarn-macros:after",
-    "-Xfatal-warnings",
     "-language:higherKinds",
   ),
   scalacOptions ++= (

--- a/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
+++ b/chimney/src/main/scala/io/scalaland/chimney/internal/macros/TransformerMacros.scala
@@ -99,11 +99,10 @@ trait TransformerMacros extends TransformerConfigSupport with MappingMacros with
                    ${transformerTree.tree}
                  }
 
-                 @annotation.nowarn
                  override def renames: Map[String, String] = ${transformerTree.renamesMapTree}
                }
             """
-          /* Suppressing "Generated class io.scalaland.chimney.DslSpec$$anon$143 differs only in case
+          /* Renames field macro might produce the "Generated class io.scalaland.chimney.DslSpec$$anon$143 differs only in case
                from io.scalaland.chimney.DslSpec$$anon$143. Such classes will overwrite one another on case-insensitive
                filesystems" warnings, which occur if implicitly-converted transformer is used.
                This condition should not be a problem, since these classes are essentially the same one.


### PR DESCRIPTION
reason: I don't have a good workaround for the warning in question. It occurs only in a particular case, and there's no simple way to add the annotation only for that case. 
The problem is that `@nowarn` annotation produces the warning if there were no suppressed warnings `warning: @nowarn annotation does not suppress any warnings`